### PR TITLE
avr-gcc 4.9.2 fixes

### DIFF
--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,0 +1,7 @@
+*.d
+*.lst
+*.eep
+*.elf
+*.lss
+*.map
+*.sym

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -43,6 +43,7 @@ CFLAGS = -g -O$(OPT) \
 -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums \
 -Wall -Wstrict-prototypes \
 -DF_CPU=$(F_CPU) \
+-D__DELAY_BACKWARD_COMPATIBLE__ \
 -Wa,-adhlns=$(<:.c=.lst) \
 $(patsubst %,-I%,$(EXTRAINCDIRS))
 

--- a/firmware/anim.c
+++ b/firmware/anim.c
@@ -654,7 +654,7 @@ uint8_t intersectrect(uint8_t x1, uint8_t y1, uint8_t w1, uint8_t h1,
 }
 
 // 8 pixels high
-static unsigned char __attribute__ ((progmem)) BigFont[] = {
+static const unsigned char __attribute__ ((progmem)) BigFont[] = {
 	0xFF, 0x81, 0x81, 0xFF,// 0
 	0x00, 0x00, 0x00, 0xFF,// 1
 	0x9F, 0x91, 0x91, 0xF1,// 2
@@ -668,7 +668,7 @@ static unsigned char __attribute__ ((progmem)) BigFont[] = {
 	0x00, 0x00, 0x00, 0x00,// SPACE
 };
 
-static unsigned char __attribute__ ((progmem)) MonthText[] = {
+static const unsigned char __attribute__ ((progmem)) MonthText[] = {
 	0,0,0,
 	'J','A','N',
 	'F','E','B',
@@ -684,7 +684,7 @@ static unsigned char __attribute__ ((progmem)) MonthText[] = {
 	'D','E','C',
 };
 
-static unsigned char __attribute__ ((progmem)) DOWText[] = {
+static const unsigned char __attribute__ ((progmem)) DOWText[] = {
 	'S','U','N',
 	'M','O','N',
 	'T','U','E',

--- a/firmware/font5x7.h
+++ b/firmware/font5x7.h
@@ -17,7 +17,7 @@
 
 // standard ascii 5x7 font
 // defines ascii characters 0x20-0x7F (32-127)
-static unsigned char __attribute__ ((progmem)) Font5x7[] = {
+static const unsigned char __attribute__ ((progmem)) Font5x7[] = {
 	0x00, 0x00, 0x00, 0x00, 0x00,// (space)
 	0x00, 0x00, 0x5F, 0x00, 0x00,// !
 	0x00, 0x07, 0x00, 0x07, 0x00,// "

--- a/firmware/fontgr.h
+++ b/firmware/fontgr.h
@@ -20,7 +20,7 @@
 	#include <avr/pgmspace.h>
 #endif
 
-static unsigned char __attribute__ ((progmem)) FontGr[] =
+static const unsigned char __attribute__ ((progmem)) FontGr[] =
 {
 // format is one character per line:
 // length, byte array[length]


### PR DESCRIPTION
- Define `__DELAY_BACKWARD_COMPATIBLE__` so that `avr-gcc` will not fail to compile `_delay_ms()` in `util/delay.h`.
- Add `const` keywords to read-only variables intended for the read-only data section.
- Added a `.gitignore` file.
