### PR TITLE
Makefile fixes

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -106,6 +106,7 @@ AVRDUDE_PORT = com5	   # programmer connected to serial device
 #AVRDUDE_PORT = /dev/cu.KeySerial1	   # programmer connected to serial device
 #AVRDUDE_PORT = /dev/cu.PL2303-0B2
 #AVRDUDE_PORT = lpt1	# programmer connected to parallel port
+#AVRDUDE_PORT = /dev/ttyUSBx	# programmer connected to USB port
 
 AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 #AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -111,7 +111,9 @@ AVRDUDE_PORT = com5	   # programmer connected to serial device
 AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 #AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
 
-AVRDUDE_FLAGS = -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
+AVRDUDE_BAUDRATE = 57600
+
+AVRDUDE_FLAGS = -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER) -b $(AVRDUDE_BAUDRATE)
 
 # Uncomment the following if you want avrdude's erase cycle counter.
 # Note that this counter needs to be initialized first using -Yn,

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -99,7 +99,7 @@ LDFLAGS = -Wl,-Map=$(TARGET).map,--cref
 #
 #AVRDUDE_PROGRAMMER = dt006
 #AVRDUDE_PROGRAMMER = stk500v2
-AVRDUDE_PROGRAMMER = usbtiny
+AVRDUDE_PROGRAMMER = arduino
 
 
 AVRDUDE_PORT = com5	   # programmer connected to serial device


### PR DESCRIPTION
- Changed the programmer to `arduino`, which is what [Emuchron](https://github.com/tceulema/Emuchron/blob/master/support/avrdude.txt) recommends.
  - `avrdude -p usbtiny -P /dev/ttyUSB3` would not work for me, but `avrdude -p ardunio -P /dev/ttyUSB3` would. 
- Added an example for uploading to a programmer connected to a USB port, such as Adafruit's own FTDI USB cable.
